### PR TITLE
Remove '/pub' from category image urls

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -60,7 +60,7 @@ class Config
      */
     public function getFileBaseUrl($path)
     {
-        return $this->_storeManager->getStore()->getBaseUrl().DirectoryList::PUB.'/'.DirectoryList::MEDIA.'/'.$path;
+        return $this->_storeManager->getStore()->getBaseUrl().'/'.DirectoryList::MEDIA.'/'.$path;
     }
 
     /**


### PR DESCRIPTION
Currently, the category icons return 404's, because `pub` is included in the image URL. `pub` should be configured as the root, so i've removed this from the function  `getFileBaseUrl`.

![faq](https://user-images.githubusercontent.com/14849044/29822452-cf1acf78-8ccb-11e7-96da-3e4dbe277172.png)
