### PR TITLE
Change the way of getting the media path

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -10,6 +10,7 @@
 
 namespace PHPCuong\Faq\Helper;
 
+use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPCuong\Faq\Model\ResourceModel\Faq as FaqResourceModel;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -60,7 +61,7 @@ class Config
      */
     public function getFileBaseUrl($path)
     {
-        return '/'.DirectoryList::PUB.'/'.DirectoryList::MEDIA.'/'.$path;
+        return $this ->_storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . $path;
     }
 
     /**


### PR DESCRIPTION
In some of my projects the images of this module aren't working because the `pub` path is included in the URL. This changes solves that problem.